### PR TITLE
feat:revamp ui of Po

### DIFF
--- a/app/components/DetailsSection.tsx
+++ b/app/components/DetailsSection.tsx
@@ -1,0 +1,205 @@
+"use client";
+import React, { useState } from "react";
+import { motion } from "framer-motion";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { stats } from "./data";
+import { Bike } from "lucide-react";
+
+const DetailsSection = () => {
+  const [hoveredStat, setHoveredStat] = useState<number | null>(null);
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
+      {/* Left Side - Stats */}
+      <div className="space-y-6">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">
+            Inspection Overview
+          </h2>
+          <p className="text-gray-600 mb-6">
+            Real-time insights into your vehicle inspection operations. Track
+            performance, monitor progress, and optimize your workflow with
+            comprehensive analytics.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          {stats.map((stat, index) => (
+            <motion.div
+              key={index}
+              className="relative"
+              onHoverStart={() => setHoveredStat(index)}
+              onHoverEnd={() => setHoveredStat(null)}
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.98 }}
+            >
+              <Card className="border-white/60 bg-white/90 backdrop-blur cursor-pointer overflow-hidden">
+                <CardContent className="p-4">
+                  <div className="flex items-center justify-between mb-2">
+                    <stat.icon className={`h-5 w-5 ${stat.color}`} />
+                    <motion.div
+                      animate={{
+                        rotate: hoveredStat === index ? 360 : 0,
+                      }}
+                      transition={{ duration: 0.5 }}
+                      className={`w-2 h-2 rounded-full ${stat.color.replace(
+                        "text-",
+                        "bg-"
+                      )}`}
+                    />
+                  </div>
+                  <div className="text-2xl font-bold text-gray-900 mb-1">
+                    {stat.value}
+                  </div>
+                  <div className="text-xs text-gray-500 mb-2">{stat.label}</div>
+                  <motion.div
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{
+                      opacity: hoveredStat === index ? 1 : 0.7,
+                      y: hoveredStat === index ? 0 : 5,
+                    }}
+                    transition={{ duration: 0.2 }}
+                    className="text-xs text-emerald-600 font-medium"
+                  >
+                    {stat.trend}
+                  </motion.div>
+                </CardContent>
+              </Card>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+
+      {/* Right Side - Interactive Bike */}
+      <div className="flex items-center justify-center">
+        <motion.div
+          className="relative w-full max-w-md h-80 flex items-center justify-center"
+          whileHover="hover"
+        >
+          {/* Bike Container */}
+          <motion.div
+            className="relative w-72 h-72 rounded-full bg-gradient-to-br from-blue-100 via-white to-emerald-100 border border-white/60 backdrop-blur shadow-xl flex items-center justify-center"
+            variants={{
+              hover: {
+                scale: 1.05,
+                rotate: [0, -2, 2, 0],
+                transition: {
+                  rotate: {
+                    repeat: Infinity,
+                    duration: 4,
+                    ease: "easeInOut",
+                  },
+                },
+              },
+            }}
+            whileTap={{ scale: 0.98 }}
+          >
+            {/* Decorative rings */}
+            <motion.div
+              className="absolute inset-4 rounded-full border-2 border-blue-200/50"
+              variants={{
+                hover: {
+                  rotate: 360,
+                  transition: {
+                    duration: 8,
+                    ease: "linear",
+                    repeat: Infinity,
+                  },
+                },
+              }}
+            />
+            <motion.div
+              className="absolute inset-8 rounded-full border border-emerald-200/50"
+              variants={{
+                hover: {
+                  rotate: -360,
+                  transition: {
+                    duration: 12,
+                    ease: "linear",
+                    repeat: Infinity,
+                  },
+                },
+              }}
+            />
+
+            {/* Main Bike Icon */}
+            <motion.div
+              variants={{
+                hover: {
+                  y: [-5, 5, -5],
+                  transition: {
+                    repeat: Infinity,
+                    duration: 3,
+                    ease: "easeInOut",
+                  },
+                },
+              }}
+            >
+              <Bike className="h-20 w-20 text-gray-700" />
+            </motion.div>
+
+            {/* Floating elements */}
+            <motion.div
+              className="absolute top-6 right-6 w-3 h-3 rounded-full bg-blue-400"
+              variants={{
+                hover: {
+                  scale: [1, 1.5, 1],
+                  opacity: [0.5, 1, 0.5],
+                  transition: {
+                    repeat: Infinity,
+                    duration: 2,
+                    ease: "easeInOut",
+                  },
+                },
+              }}
+            />
+            <motion.div
+              className="absolute bottom-8 left-8 w-2 h-2 rounded-full bg-emerald-400"
+              variants={{
+                hover: {
+                  scale: [1, 1.2, 1],
+                  opacity: [0.7, 1, 0.7],
+                  transition: {
+                    repeat: Infinity,
+                    duration: 1.5,
+                    ease: "easeInOut",
+                    delay: 0.5,
+                  },
+                },
+              }}
+            />
+            <motion.div
+              className="absolute top-12 left-12 w-1.5 h-1.5 rounded-full bg-purple-400"
+              variants={{
+                hover: {
+                  scale: [1, 1.8, 1],
+                  opacity: [0.4, 1, 0.4],
+                  transition: {
+                    repeat: Infinity,
+                    duration: 2.5,
+                    ease: "easeInOut",
+                    delay: 1,
+                  },
+                },
+              }}
+            />
+          </motion.div>
+
+          {/* Interactive prompt */}
+          <motion.div
+            className="absolute -bottom-4 left-1/2 transform -translate-x-1/2 text-center"
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.5 }}
+          >
+            <p className="text-sm text-gray-500 font-medium">
+              Hover to interact
+            </p>
+          </motion.div>
+        </motion.div>
+      </div>
+    </div>
+  );
+};
+
+export default DetailsSection;

--- a/app/components/VehicleCardSection.tsx
+++ b/app/components/VehicleCardSection.tsx
@@ -1,0 +1,145 @@
+"use client";
+import React from "react";
+import { motion } from "framer-motion";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import {
+  ArrowLeft,
+  Radio,
+  Bike as BikeIcon,
+  MapPin,
+  Gauge,
+  CalendarClock,
+  Bike,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+
+type VehicleStatus = "Pending" | "In Progress" | "Completed";
+
+const VehicleCardSection = ({ filtered }: { filtered: any }) => {
+  const router = useRouter();
+  const handleStartLive = () => router.push("/live");
+  const handleBikeClick = (id: number) => {
+    router.push(`/vehicles/${id}`);
+  };
+
+  const statusStyles: Record<VehicleStatus, string> = {
+    Pending: "bg-amber-100 text-amber-800 border-amber-200",
+    "In Progress": "bg-blue-100 text-blue-800 border-blue-200",
+    Completed: "bg-emerald-100 text-emerald-800 border-emerald-200",
+  };
+
+  const hoverStyles: Record<VehicleStatus, string> = {
+    Pending: "hover:shadow-yellow-400/50",
+    "In Progress": "hover:shadow-blue-400/50",
+    Completed: "hover:shadow-green-400/50",
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {filtered.map((bike: any) => (
+        <motion.div
+          key={bike.id}
+          whileHover={{ y: -4 }}
+          whileTap={{ scale: 0.98 }}
+          transition={{ duration: 0.2 }}
+        >
+          <Card
+            role="button"
+            tabIndex={0}
+            onClick={() => handleBikeClick(bike.id)}
+            onKeyDown={(e) => e.key === "Enter" && handleBikeClick(bike.id)}
+            className={`group overflow-hidden border-white/60 bg-white/90 backdrop-blur transition-all duration-300 cursor-pointer hover:shadow-xl ${
+              hoverStyles[bike.status as VehicleStatus]
+            }`}
+          >
+            <CardHeader className="pb-2">
+              <div className="flex items-start justify-between gap-3">
+                <CardTitle className="text-lg font-semibold leading-tight group-hover:text-blue-600 transition-colors">
+                  {bike.name}
+                </CardTitle>
+                <Badge
+                  variant="outline"
+                  className={`border ${
+                    statusStyles[bike.status as VehicleStatus]
+                  }`}
+                >
+                  {bike.status}
+                </Badge>
+              </div>
+              <div className="text-xs text-gray-500 mt-1">
+                {bike.year} • {bike.color} • {bike.regNo}
+              </div>
+            </CardHeader>
+
+            <CardContent className="pt-0">
+              <div className="relative w-full h-36 rounded-lg overflow-hidden bg-gray-100">
+                {bike.thumb ? (
+                  <img
+                    src={bike.thumb}
+                    alt={`${bike.name} photo`}
+                    className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-gray-400 group-hover:text-gray-600 transition-colors">
+                    <Bike className="h-10 w-10" />
+                  </div>
+                )}
+              </div>
+
+              <div className="mt-3 space-y-2 text-sm">
+                <div className="flex items-center gap-2 text-gray-700">
+                  <MapPin className="h-4 w-4 text-gray-400" />
+                  <span>{bike.location}</span>
+                </div>
+                <div className="flex items-center gap-2 text-gray-700">
+                  <Gauge className="h-4 w-4 text-gray-400" />
+                  <span>
+                    Odometer: <strong>{bike.odoKm.toLocaleString()} km</strong>
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 text-gray-700">
+                  <CalendarClock className="h-4 w-4 text-gray-400" />
+                  <span>
+                    Last inspection:{" "}
+                    <strong>
+                      {bike.lastInspection
+                        ? new Date(bike.lastInspection).toLocaleDateString()
+                        : "—"}
+                    </strong>
+                  </span>
+                </div>
+              </div>
+            </CardContent>
+
+            <Separator className="mt-2" />
+
+            <CardFooter className="flex items-center justify-between">
+              <div className="text-xs text-gray-500">
+                Tap on card to Explore
+              </div>
+
+              <Button
+                className="h-7 text-xs mt-3 p-4 rounded-full border border-gray-200 hover:border-gray-300"
+                onClick={handleStartLive}
+              >
+                <Radio className="mr-2 h-4 w-4" />
+                Start live inspection
+              </Button>
+            </CardFooter>
+          </Card>
+        </motion.div>
+      ))}
+    </div>
+  );
+};
+
+export default VehicleCardSection;

--- a/app/components/VehicleDetails.tsx
+++ b/app/components/VehicleDetails.tsx
@@ -1,9 +1,12 @@
 "use client";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
+import { Progress } from "@/components/ui/progress";
 import {
   ArrowLeft,
   Radio,
@@ -11,13 +14,30 @@ import {
   MapPin,
   Gauge,
   CalendarClock,
+  AlertTriangle,
+  CheckCircle,
+  Clock,
+  Camera,
+  Video,
+  FileText,
+  Download,
+  Eye,
+  Play,
+  Maximize2,
+  X,
+  Settings,
+  Activity,
+  Wrench,
+  Fuel,
+  Battery,
+  Thermometer,
 } from "lucide-react";
+import VehicleDetailsTabView from "./VehicleDetailsTabView";
 
-/* --- Demo data (richer fields) --- */
 type Vehicle = {
   id: number;
   name: string;
-  details: string; // kept from your original
+  details: string;
   year: number;
   color: string;
   regNo: string;
@@ -79,76 +99,80 @@ const statusStyles: Record<Vehicle["status"], string> = {
 export default function VehicleDetails({ bikeId }: { bikeId: string }) {
   const router = useRouter();
   const bike = bikes.find((b) => b.id === parseInt(bikeId));
-
-  const handleStartLive = () => router.push("/live");
+  const [selectedMedia, setSelectedMedia] = useState<any>(null);
 
   if (!bike) {
     return (
       <div className="min-h-screen w-full flex items-center justify-center px-4">
-        <Card className="max-w-sm w-full text-center">
-          <CardHeader>
-            <CardTitle>Vehicle not found</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-gray-600">
-              The vehicle you’re looking for doesn’t exist or may have been removed.
-            </p>
-            <Button className="mt-4 w-full" onClick={() => router.push("/vehicles")}>
-              Back to Vehicles
-            </Button>
-          </CardContent>
-        </Card>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+        >
+          <Card className="max-w-sm w-full text-center">
+            <CardHeader>
+              <CardTitle>Vehicle not found</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-gray-600 mb-4">
+                The vehicle you're looking for doesn't exist or may have been
+                removed.
+              </p>
+              <Button
+                className="w-full"
+                onClick={() => router.push("/vehicles")}
+              >
+                Back to Vehicles
+              </Button>
+            </CardContent>
+          </Card>
+        </motion.div>
       </div>
     );
   }
 
   return (
     <div className="min-h-screen w-full bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.10),transparent_45%),radial-gradient(ellipse_at_bottom_right,rgba(16,185,129,0.10),transparent_45%)] px-4 py-6">
-      {/* Header / Brand */}
-      <div className="mx-auto max-w-4xl mb-4 flex items-center justify-between">
-        <button
+      {/* Header */}
+      <motion.div
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="mx-auto max-w-6xl mb-6 flex items-center justify-between"
+      >
+        <Button
+          variant="ghost"
           onClick={() => router.back()}
-          className="inline-flex items-center gap-2 text-sm text-gray-700 hover:text-gray-900"
-          aria-label="Go back"
+          className="flex items-center gap-2 hover:bg-white/50"
         >
           <ArrowLeft className="h-4 w-4" />
           Back
-        </button>
+        </Button>
         <div className="text-right">
-          <div className="text-xs text-gray-600">App</div>
+          <div className="text-xs text-gray-600">Vehicle Inspection</div>
           <div className="text-2xl font-extrabold tracking-tight">
             <span className="bg-clip-text text-transparent bg-gradient-to-r from-blue-600 via-emerald-600 to-blue-600">
-              LiveX
+              Po
             </span>
           </div>
         </div>
-      </div>
+      </motion.div>
 
-      {/* Main Card */}
-      <div className="mx-auto max-w-4xl">
+      {/* Vehicle Header Card */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="mx-auto max-w-6xl mb-6"
+      >
         <Card className="border-white/60 bg-white/85 backdrop-blur">
-          <CardHeader className="pb-2">
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <CardTitle className="text-xl sm:text-2xl leading-tight">
-                  {bike.name}
-                </CardTitle>
-                <p className="text-sm text-gray-600 mt-1">{bike.details}</p>
-              </div>
-              <Badge variant="outline" className={`border ${statusStyles[bike.status]}`}>
-                {bike.status}
-              </Badge>
-            </div>
-          </CardHeader>
-
-          <CardContent>
-            {/* Media + Specs */}
-            <div className="grid grid-cols-1 sm:grid-cols-5 gap-5">
-              {/* Media */}
-              <div className="sm:col-span-2">
-                <div className="relative w-full h-44 sm:h-56 rounded-lg overflow-hidden bg-gray-100">
+          <CardContent className="p-6">
+            <div className="flex flex-col lg:flex-row gap-6">
+              {/* Vehicle Image */}
+              <div className="lg:w-1/3">
+                <motion.div
+                  className="relative w-full h-48 lg:h-64 rounded-lg overflow-hidden bg-gray-100"
+                  whileHover={{ scale: 1.02 }}
+                  transition={{ duration: 0.2 }}
+                >
                   {bike.thumb ? (
-                    // eslint-disable-next-line @next/next/no-img-element
                     <img
                       src={bike.thumb}
                       alt={`${bike.name} photo`}
@@ -156,83 +180,148 @@ export default function VehicleDetails({ bikeId }: { bikeId: string }) {
                     />
                   ) : (
                     <div className="w-full h-full flex items-center justify-center text-gray-400">
-                      <BikeIcon className="h-10 w-10" />
+                      <BikeIcon className="h-16 w-16" />
                     </div>
                   )}
-                </div>
+                  <div className="absolute top-4 right-4">
+                    <Badge
+                      variant="outline"
+                      className={`border ${
+                        statusStyles[bike.status]
+                      } backdrop-blur`}
+                    >
+                      {bike.status}
+                    </Badge>
+                  </div>
+                </motion.div>
               </div>
 
-              {/* Specs */}
-              <div className="sm:col-span-3">
-                <div className="grid grid-cols-2 gap-3 text-sm">
-                  <div className="rounded-md border bg-white px-3 py-2">
-                    <div className="text-[11px] uppercase tracking-wide text-gray-500">Year</div>
-                    <div className="font-medium">{bike.year}</div>
-                  </div>
-                  <div className="rounded-md border bg-white px-3 py-2">
-                    <div className="text-[11px] uppercase tracking-wide text-gray-500">Color</div>
-                    <div className="font-medium">{bike.color}</div>
-                  </div>
-                  <div className="rounded-md border bg-white px-3 py-2">
-                    <div className="text-[11px] uppercase tracking-wide text-gray-500">Registration</div>
-                    <div className="font-medium">{bike.regNo}</div>
-                  </div>
-                  <div className="rounded-md border bg-white px-3 py-2">
-                    <div className="text-[11px] uppercase tracking-wide text-gray-500">Odometer</div>
-                    <div className="font-medium">{bike.odoKm.toLocaleString()} km</div>
-                  </div>
-                  <div className="rounded-md border bg-white px-3 py-2 col-span-2">
-                    <div className="text-[11px] uppercase tracking-wide text-gray-500">Location</div>
-                    <div className="font-medium flex items-center gap-2">
-                      <MapPin className="h-4 w-4 text-gray-400" />
-                      {bike.location}
-                    </div>
-                  </div>
+              {/* Vehicle Info */}
+              <div className="lg:w-2/3">
+                <div className="mb-4">
+                  <h1 className="text-2xl lg:text-3xl font-bold text-gray-900 mb-2">
+                    {bike.name}
+                  </h1>
+                  <p className="text-gray-600">{bike.details}</p>
                 </div>
 
-                <div className="mt-3 flex flex-wrap items-center gap-3 text-sm text-gray-700">
-                  <div className="inline-flex items-center gap-2">
-                    <CalendarClock className="h-4 w-4 text-gray-400" />
-                    Last inspection:
-                    <span className="font-semibold">
-                      {bike.lastInspection
-                        ? new Date(bike.lastInspection).toLocaleDateString()
-                        : "—"}
-                    </span>
+                <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+                  {[
+                    { label: "Year", value: bike.year, icon: CalendarClock },
+                    { label: "Color", value: bike.color, icon: Settings },
+                    {
+                      label: "Registration",
+                      value: bike.regNo,
+                      icon: FileText,
+                    },
+                    {
+                      label: "Odometer",
+                      value: `${bike.odoKm.toLocaleString()} km`,
+                      icon: Gauge,
+                    },
+                  ].map((item, index) => (
+                    <motion.div
+                      key={item.label}
+                      initial={{ opacity: 0, y: 20 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ delay: index * 0.1 }}
+                      className="bg-white rounded-lg p-3 border border-gray-200"
+                    >
+                      <div className="flex items-center gap-2 mb-1">
+                        <item.icon className="h-4 w-4 text-gray-400" />
+                        <span className="text-xs text-gray-500 uppercase tracking-wide">
+                          {item.label}
+                        </span>
+                      </div>
+                      <div className="font-semibold text-gray-900">
+                        {item.value}
+                      </div>
+                    </motion.div>
+                  ))}
+                </div>
+
+                <div className="mt-4 flex items-center gap-4 text-sm text-gray-600">
+                  <div className="flex items-center gap-2">
+                    <MapPin className="h-4 w-4" />
+                    {bike.location}
                   </div>
-                  <div className="inline-flex items-center gap-2">
-                    <Gauge className="h-4 w-4 text-gray-400" />
-                    Health: <span className="font-semibold">—</span>
+                  <div className="flex items-center gap-2">
+                    <CalendarClock className="h-4 w-4" />
+                    Last inspection:{" "}
+                    {bike.lastInspection
+                      ? new Date(bike.lastInspection).toLocaleDateString()
+                      : "—"}
                   </div>
                 </div>
               </div>
             </div>
-
-            <Separator className="my-5" />
-
-            {/* Actions */}
-            <div className="flex flex-col sm:flex-row gap-3">
-              <Button className="h-11 text-base" onClick={handleStartLive}>
-                <Radio className="mr-2 h-4 w-4" />
-                Start Live
-              </Button>
-              <Button
-                variant="secondary"
-                className="h-11 text-base"
-                onClick={() => router.push("/vehicles")}
-              >
-                <ArrowLeft className="mr-2 h-4 w-4" />
-                Back to Vehicles
-              </Button>
-            </div>
-
-            {/* Small note */}
-            <p className="mt-3 text-xs text-gray-500">
-              Tip: Ensure camera and microphone permissions are enabled before starting Live.
-            </p>
           </CardContent>
         </Card>
-      </div>
+      </motion.div>
+
+      {/* Tab Navigation */}
+
+      {/* Tab Content */}
+      <VehicleDetailsTabView bike={bike} setSelectedMedia={setSelectedMedia} />
+
+      {/* Media Modal */}
+      <AnimatePresence>
+        {selectedMedia && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4"
+            onClick={() => setSelectedMedia(null)}
+          >
+            <motion.div
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.9, opacity: 0 }}
+              className="bg-white rounded-lg max-w-4xl w-full max-h-[90vh] overflow-hidden"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex items-center justify-between p-4 border-b">
+                <h3 className="font-semibold text-lg">{selectedMedia.title}</h3>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setSelectedMedia(null)}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="p-4 flex items-center justify-center bg-gray-100 min-h-[300px]">
+                {selectedMedia.type === "image" ? (
+                  <Camera className="h-16 w-16 text-gray-400" />
+                ) : (
+                  <div className="flex flex-col items-center">
+                    <Video className="h-16 w-16 text-gray-400 mb-4" />
+                    <Badge>{selectedMedia.duration}</Badge>
+                  </div>
+                )}
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Action Button */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.5 }}
+        className="fixed bottom-6 right-6"
+      >
+        <Button
+          size="lg"
+          className="rounded-full shadow-lg hover:shadow-xl transition-shadow"
+          onClick={() => router.push("/vehicles")}
+        >
+          <ArrowLeft className="mr-2 h-5 w-5" />
+          Back to Vehicles
+        </Button>
+      </motion.div>
     </div>
   );
 }

--- a/app/components/VehicleDetailsTabView.tsx
+++ b/app/components/VehicleDetailsTabView.tsx
@@ -1,0 +1,429 @@
+"use client";
+import React, { useState } from "react";
+import { AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import {
+  AlertTriangle,
+  CheckCircle,
+  Camera,
+  Video,
+  Eye,
+  Play,
+  Settings,
+  Activity,
+  Wrench,
+  Fuel,
+  Battery,
+  Thermometer,
+} from "lucide-react";
+import { mockIssues, mockMedia, mockSummary, tabs } from "./data";
+import { Button } from "@/components/ui/button";
+
+const VehicleDetailsTabView = ({
+  bike,
+  setSelectedMedia,
+}: {
+  bike: any;
+  setSelectedMedia: (media: any) => void;
+}) => {
+  const [activeTab, setActiveTab] = useState("details");
+  const [hoveredCategory, setHoveredCategory] = useState<string | null>(null);
+
+  const severityColors = {
+    High: "text-red-600 bg-red-50",
+    Medium: "text-orange-600 bg-orange-50",
+    Low: "text-green-600 bg-green-50",
+  };
+
+  const statusColors = {
+    Open: "text-red-600 bg-red-50",
+    "In Progress": "text-blue-600 bg-blue-50",
+    Resolved: "text-green-600 bg-green-50",
+  };
+
+  return (
+    <>
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2 }}
+        className="mx-auto max-w-6xl mb-6"
+      >
+        <Card className="border-white/60 bg-white/85 backdrop-blur">
+          <CardContent className="p-2">
+            <div className="flex gap-1">
+              {tabs.map((tab) => (
+                <Button
+                  key={tab.id}
+                  variant={activeTab === tab.id ? "default" : "ghost"}
+                  className={`flex-1 flex items-center gap-2 h-12 ${
+                    activeTab === tab.id
+                      ? "bg-gray-900 text-white"
+                      : "hover:bg-white/50"
+                  }`}
+                  onClick={() => setActiveTab(tab.id)}
+                >
+                  <tab.icon className="h-4 w-4" />
+                  <span className="hidden sm:inline">{tab.label}</span>
+                </Button>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </motion.div>
+      <div className="mx-auto max-w-6xl">
+        <AnimatePresence mode="wait">
+          {activeTab === "details" && (
+            <motion.div
+              key="details"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+            >
+              <Card className="border-white/60 bg-white/85 backdrop-blur">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <Settings className="h-5 w-5" />
+                    Vehicle Details & Specifications
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                    <div className="space-y-4">
+                      <h3 className="font-semibold text-lg">
+                        Basic Information
+                      </h3>
+                      <div className="grid grid-cols-2 gap-4">
+                        {[
+                          { label: "Make & Model", value: bike.name },
+                          { label: "Year", value: bike.year },
+                          { label: "Color", value: bike.color },
+                          { label: "Registration", value: bike.regNo },
+                          { label: "Current Location", value: bike.location },
+                          { label: "Status", value: bike.status },
+                        ].map((item, index) => (
+                          <motion.div
+                            key={item.label}
+                            initial={{ opacity: 0, x: -20 }}
+                            animate={{ opacity: 1, x: 0 }}
+                            transition={{ delay: index * 0.1 }}
+                            className="bg-gray-50 rounded-lg p-3"
+                          >
+                            <div className="text-xs text-gray-500 mb-1">
+                              {item.label}
+                            </div>
+                            <div className="font-medium">{item.value}</div>
+                          </motion.div>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="space-y-4">
+                      <h3 className="font-semibold text-lg">
+                        Performance Metrics
+                      </h3>
+                      <div className="space-y-4">
+                        {[
+                          {
+                            label: "Engine Health",
+                            value: 92,
+                            icon: Settings,
+                            color: "text-green-600",
+                          },
+                          {
+                            label: "Fuel Efficiency",
+                            value: 78,
+                            icon: Fuel,
+                            color: "text-blue-600",
+                          },
+                          {
+                            label: "Battery Status",
+                            value: 85,
+                            icon: Battery,
+                            color: "text-purple-600",
+                          },
+                          {
+                            label: "Temperature",
+                            value: 68,
+                            icon: Thermometer,
+                            color: "text-orange-600",
+                          },
+                        ].map((metric, index) => (
+                          <motion.div
+                            key={metric.label}
+                            initial={{ opacity: 0, x: 20 }}
+                            animate={{ opacity: 1, x: 0 }}
+                            transition={{ delay: index * 0.1 }}
+                            className="bg-gray-50 rounded-lg p-4"
+                          >
+                            <div className="flex items-center justify-between mb-2">
+                              <div className="flex items-center gap-2">
+                                <metric.icon
+                                  className={`h-4 w-4 ${metric.color}`}
+                                />
+                                <span className="font-medium">
+                                  {metric.label}
+                                </span>
+                              </div>
+                              <span className="font-bold">{metric.value}%</span>
+                            </div>
+                            <Progress value={metric.value} className="h-2" />
+                          </motion.div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            </motion.div>
+          )}
+
+          {activeTab === "issues" && (
+            <motion.div
+              key="issues"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+            >
+              <Card className="border-white/60 bg-white/85 backdrop-blur">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <AlertTriangle className="h-5 w-5" />
+                    Issues & Findings ({mockIssues.length})
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-4">
+                    {mockIssues.map((issue, index) => (
+                      <motion.div
+                        key={issue.id}
+                        initial={{ opacity: 0, y: 20 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ delay: index * 0.1 }}
+                        whileHover={{ scale: 1.02 }}
+                        className="bg-white rounded-lg border border-gray-200 p-4 cursor-pointer"
+                      >
+                        <div className="flex items-start justify-between mb-3">
+                          <h3 className="font-semibold text-lg">
+                            {issue.title}
+                          </h3>
+                          <div className="flex gap-2">
+                            <Badge
+                              className={
+                                severityColors[
+                                  issue.severity as keyof typeof severityColors
+                                ]
+                              }
+                            >
+                              {issue.severity}
+                            </Badge>
+                            <Badge
+                              className={
+                                statusColors[
+                                  issue.status as keyof typeof statusColors
+                                ]
+                              }
+                            >
+                              {issue.status}
+                            </Badge>
+                          </div>
+                        </div>
+                        <p className="text-gray-600 mb-2">
+                          {issue.description}
+                        </p>
+                        <div className="text-sm text-gray-500">
+                          Category:{" "}
+                          <span className="font-medium">{issue.category}</span>
+                        </div>
+                      </motion.div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            </motion.div>
+          )}
+
+          {activeTab === "media" && (
+            <motion.div
+              key="media"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+            >
+              <Card className="border-white/60 bg-white/85 backdrop-blur">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <Camera className="h-5 w-5" />
+                    Images & Videos ({mockMedia.length})
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                    {mockMedia.map((item, index) => (
+                      <motion.div
+                        key={item.id}
+                        initial={{ opacity: 0, scale: 0.9 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        transition={{ delay: index * 0.1 }}
+                        whileHover={{ scale: 1.05 }}
+                        className="relative bg-gray-100 rounded-lg overflow-hidden cursor-pointer"
+                        onClick={() => setSelectedMedia(item)}
+                      >
+                        <div className="aspect-video flex items-center justify-center">
+                          {item.type === "image" ? (
+                            <Camera className="h-8 w-8 text-gray-400" />
+                          ) : (
+                            <div className="flex flex-col items-center">
+                              <Video className="h-8 w-8 text-gray-400 mb-2" />
+                              <Badge variant="outline">{item.duration}</Badge>
+                            </div>
+                          )}
+                        </div>
+                        <div className="absolute inset-0 bg-black/0 hover:bg-black/20 transition-colors flex items-center justify-center">
+                          <div className="opacity-0 hover:opacity-100 transition-opacity">
+                            {item.type === "image" ? (
+                              <Eye className="h-6 w-6 text-white" />
+                            ) : (
+                              <Play className="h-6 w-6 text-white" />
+                            )}
+                          </div>
+                        </div>
+                        <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/50 p-3">
+                          <div className="text-white text-sm font-medium">
+                            {item.title}
+                          </div>
+                          <div className="text-white/70 text-xs">
+                            {new Date(item.timestamp).toLocaleString()}
+                          </div>
+                        </div>
+                      </motion.div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            </motion.div>
+          )}
+
+          {activeTab === "summary" && (
+            <motion.div
+              key="summary"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+            >
+              <div className="space-y-6">
+                {/* Overall Score */}
+                <Card className="border-white/60 bg-white/85 backdrop-blur">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      <Activity className="h-5 w-5" />
+                      Overall Vehicle Health Score
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="flex items-center justify-center">
+                      <motion.div
+                        className="relative w-32 h-32"
+                        initial={{ scale: 0 }}
+                        animate={{ scale: 1 }}
+                        transition={{ delay: 0.3, type: "spring" }}
+                      >
+                        <div className="w-full h-full rounded-full border-8 border-gray-200 flex items-center justify-center">
+                          <div className="text-3xl font-bold text-gray-900">
+                            {mockSummary.overallScore}%
+                          </div>
+                        </div>
+                        <div
+                          className="absolute inset-0 rounded-full border-8 border-transparent border-t-green-500 border-r-green-500 transform -rotate-90"
+                          style={{
+                            borderImage: `conic-gradient(#10b981 ${
+                              mockSummary.overallScore * 3.6
+                            }deg, transparent 0deg) 1`,
+                          }}
+                        ></div>
+                      </motion.div>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                {/* Category Breakdown */}
+                <Card className="border-white/60 bg-white/85 backdrop-blur">
+                  <CardHeader>
+                    <CardTitle>Category Breakdown</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      {mockSummary.categories.map((category, index) => (
+                        <motion.div
+                          key={category.name}
+                          initial={{ opacity: 0, x: -20 }}
+                          animate={{ opacity: 1, x: 0 }}
+                          transition={{ delay: index * 0.1 }}
+                          onHoverStart={() => setHoveredCategory(category.name)}
+                          onHoverEnd={() => setHoveredCategory(null)}
+                          className="bg-gray-50 rounded-lg p-4 cursor-pointer"
+                        >
+                          <div className="flex items-center justify-between mb-2">
+                            <span className="font-medium">{category.name}</span>
+                            <motion.span
+                              className="font-bold"
+                              animate={{
+                                scale:
+                                  hoveredCategory === category.name ? 1.1 : 1,
+                                color:
+                                  hoveredCategory === category.name
+                                    ? "#059669"
+                                    : "#374151",
+                              }}
+                            >
+                              {category.score}%
+                            </motion.span>
+                          </div>
+                          <Progress value={category.score} className="mb-2" />
+                          <div className="text-sm text-gray-600">
+                            {category.status}
+                          </div>
+                        </motion.div>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+
+                {/* Recommendations */}
+                <Card className="border-white/60 bg-white/85 backdrop-blur">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      <Wrench className="h-5 w-5" />
+                      Recommendations
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="space-y-3">
+                      {mockSummary.recommendations.map((rec, index) => (
+                        <motion.div
+                          key={index}
+                          initial={{ opacity: 0, x: -20 }}
+                          animate={{ opacity: 1, x: 0 }}
+                          transition={{ delay: index * 0.1 }}
+                          className="flex items-start gap-3 p-3 bg-blue-50 rounded-lg border border-blue-200"
+                        >
+                          <CheckCircle className="h-5 w-5 text-blue-600 mt-0.5" />
+                          <span className="text-blue-800">{rec}</span>
+                        </motion.div>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </>
+  );
+};
+
+export default VehicleDetailsTabView;

--- a/app/components/VehicleList.tsx
+++ b/app/components/VehicleList.tsx
@@ -1,75 +1,35 @@
 "use client";
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { Bike, MapPin, Gauge, CalendarClock, Search, Filter, ChevronRight } from "lucide-react";
+import {
+  Bike,
+  MapPin,
+  Gauge,
+  CalendarClock,
+  Search,
+  Filter,
+  ChevronRight,
+  Radio,
+} from "lucide-react";
+import DetailsSection from "./DetailsSection";
+import { bikes, tabs } from "./data";
+import VehicleCardSection from "./VehicleCardSection";
 
 type VehicleStatus = "Pending" | "In Progress" | "Completed";
 
-type Vehicle = {
-  id: number;
-  name: string;
-  year: number;
-  color: string;
-  regNo: string;
-  odoKm: number;
-  location: string;
-  status: VehicleStatus;
-  lastInspection?: string; // ISO date
-  thumb?: string; // optional image url
-};
-
-const bikes: Vehicle[] = [
-  {
-    id: 1,
-    name: "Royal Enfield Classic 350",
-    year: 2022,
-    color: "Black",
-    regNo: "MH12 AB 3456",
-    odoKm: 12850,
-    location: "Pune Yard A",
-    status: "Pending",
-    lastInspection: "2025-08-30",
-    thumb: "/images/bikes/classic350.jpg",
-  },
-  {
-    id: 2,
-    name: "Bajaj Pulsar NS200",
-    year: 2023,
-    color: "Red",
-    regNo: "DL3C XY 9087",
-    odoKm: 5400,
-    location: "Delhi Lot 3",
-    status: "In Progress",
-    lastInspection: "2025-09-02",
-    thumb: "/images/bikes/ns200.jpg",
-  },
-  {
-    id: 3,
-    name: "TVS Apache RTR 160",
-    year: 2021,
-    color: "Blue",
-    regNo: "KA05 MN 2211",
-    odoKm: 20350,
-    location: "Bengaluru Zone 1",
-    status: "Completed",
-    lastInspection: "2025-08-25",
-    thumb: "/images/bikes/apache160.jpg",
-  },
-];
-
-const statusStyles: Record<VehicleStatus, string> = {
-  Pending: "bg-amber-100 text-amber-800 border-amber-200",
-  "In Progress": "bg-blue-100 text-blue-800 border-blue-200",
-  Completed: "bg-emerald-100 text-emerald-800 border-emerald-200",
-};
-
 export default function VehicleList() {
-  const router = useRouter();
   const [q, setQ] = useState("");
   const [status, setStatus] = useState<"ALL" | VehicleStatus>("ALL");
   const [sort, setSort] = useState<"recent" | "name" | "odo">("recent");
@@ -77,7 +37,6 @@ export default function VehicleList() {
   const filtered = useMemo(() => {
     let rows = [...bikes];
 
-    // Filter by search text (name/reg no)
     if (q.trim()) {
       const needle = q.toLowerCase();
       rows = rows.filter(
@@ -87,16 +46,13 @@ export default function VehicleList() {
       );
     }
 
-    // Filter by status
     if (status !== "ALL") {
       rows = rows.filter((b) => b.status === status);
     }
 
-    // Sort
     rows.sort((a, b) => {
       if (sort === "name") return a.name.localeCompare(b.name);
       if (sort === "odo") return b.odoKm - a.odoKm;
-      // recent by lastInspection desc (fallback to newest year)
       const aTime = a.lastInspection ? Date.parse(a.lastInspection) : 0;
       const bTime = b.lastInspection ? Date.parse(b.lastInspection) : 0;
       if (aTime !== bTime) return bTime - aTime;
@@ -106,38 +62,34 @@ export default function VehicleList() {
     return rows;
   }, [q, status, sort]);
 
-  const handleBikeClick = (id: number) => {
-    router.push(`/vehicles/${id}`);
-  };
-
   return (
     <div className="min-h-screen w-full bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.10),transparent_45%),radial-gradient(ellipse_at_bottom_right,rgba(16,185,129,0.10),transparent_45%)] px-4 py-6">
-      {/* Brand + Title */}
-      <div className="mx-auto max-w-5xl mb-4">
-        <div className="flex items-end justify-between gap-3 flex-wrap">
-          <div>
-            <h1 className="text-3xl sm:text-4xl font-extrabold tracking-tight">
-              <span className="bg-clip-text text-transparent bg-gradient-to-r from-blue-600 via-emerald-600 to-blue-600">
-                LiveX
-              </span>
-            </h1>
-            <p className="text-sm text-gray-600 mt-1">Select a vehicle to view or start inspection</p>
-          </div>
-          <div className="flex items-center gap-2">
-            <Badge variant="outline" className="hidden sm:inline-flex">
-              Total: {filtered.length}/{bikes.length}
-            </Badge>
+      <div className="mx-auto max-w-7xl">
+        {/* Brand + Title */}
+        <div className="mb-8">
+          <div className="flex items-end justify-between gap-3 flex-wrap">
+            <div>
+              <h1 className="text-3xl sm:text-4xl font-extrabold tracking-tight">
+                <span className="bg-clip-text text-transparent bg-gradient-to-r from-[#000000_80%] via-[#ffffff_80%] to-[#000000_80%]">
+                  Po
+                </span>
+              </h1>
+              <p className="text-sm text-gray-600 mt-1">
+                Advanced Vehicle Inspection Management System
+              </p>
+            </div>
           </div>
         </div>
-      </div>
 
-      {/* Controls */}
-      <div className="mx-auto max-w-5xl">
-        <Card className="border-white/50 bg-white/80 backdrop-blur">
+        {/* Interactive Stats and Bike Section */}
+        <DetailsSection />
+
+        {/* Search and Filter Controls */}
+        <Card className="border-white/50 bg-white/80 backdrop-blur mb-6">
           <CardContent className="pt-6">
-            <div className="flex flex-col sm:flex-row gap-3 sm:items-center">
+            <div className="flex flex-col gap-4">
               {/* Search */}
-              <div className="relative flex-1">
+              <div className="relative">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
                 <Input
                   value={q}
@@ -147,170 +99,104 @@ export default function VehicleList() {
                 />
               </div>
 
-              {/* Status filter */}
-              <div className="flex items-center gap-2">
-                <Filter className="h-4 w-4 text-gray-400 hidden sm:block" />
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => setStatus("ALL")}
-                    className={`px-3 py-1 rounded-full text-xs border ${
-                      status === "ALL"
-                        ? "bg-gray-900 text-white border-gray-900"
-                        : "bg-white text-gray-700 border-gray-200"
-                    }`}
-                  >
-                    All
-                  </button>
-                  {(["Pending", "In Progress", "Completed"] as VehicleStatus[]).map((s) => (
+              <div className="flex flex-col sm:flex-row gap-4 sm:items-center sm:justify-between">
+                {/* Status filter */}
+                <div className="flex items-center gap-2">
+                  <Filter className="h-4 w-4 text-gray-400" />
+                  <div className="flex gap-2 flex-wrap">
                     <button
-                      key={s}
-                      onClick={() => setStatus(s)}
-                      className={`px-3 py-1 rounded-full text-xs border ${
-                        status === s
+                      onClick={() => setStatus("ALL")}
+                      className={`px-3 py-1 rounded-full text-xs border transition-colors ${
+                        status === "ALL"
                           ? "bg-gray-900 text-white border-gray-900"
-                          : "bg-white text-gray-700 border-gray-200"
+                          : "bg-white text-gray-700 border-gray-200 hover:border-gray-300"
                       }`}
                     >
-                      {s}
+                      All
                     </button>
-                  ))}
+                    {(
+                      ["Pending", "In Progress", "Completed"] as VehicleStatus[]
+                    ).map((s) => (
+                      <button
+                        key={s}
+                        onClick={() => setStatus(s)}
+                        className={`px-3 py-1 rounded-full text-xs border transition-colors ${
+                          status === s
+                            ? "bg-gray-900 text-white border-gray-900"
+                            : "bg-white text-gray-700 border-gray-200 hover:border-gray-300"
+                        }`}
+                      >
+                        {s}
+                      </button>
+                    ))}
+                  </div>
                 </div>
-              </div>
 
-              {/* Sort */}
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-gray-500">Sort:</span>
-                <div className="flex gap-1 bg-white rounded-md border border-gray-200 p-1">
-                  <button
-                    onClick={() => setSort("recent")}
-                    className={`px-3 py-1 rounded-md text-xs ${
-                      sort === "recent" ? "bg-gray-900 text-white" : "text-gray-700"
-                    }`}
-                  >
-                    Recent
-                  </button>
-                  <button
-                    onClick={() => setSort("name")}
-                    className={`px-3 py-1 rounded-md text-xs ${
-                      sort === "name" ? "bg-gray-900 text-white" : "text-gray-700"
-                    }`}
-                  >
-                    Name
-                  </button>
-                  <button
-                    onClick={() => setSort("odo")}
-                    className={`px-3 py-1 rounded-md text-xs ${
-                      sort === "odo" ? "bg-gray-900 text-white" : "text-gray-700"
-                    }`}
-                  >
-                    Odo
-                  </button>
+                {/* Sort */}
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-gray-500">Sort:</span>
+                  <div className="flex gap-1 bg-white rounded-md border border-gray-200 p-1">
+                    {[
+                      { key: "recent", label: "Recent" },
+                      { key: "name", label: "Name" },
+                      { key: "odo", label: "Odo" },
+                    ].map(({ key, label }) => (
+                      <button
+                        key={key}
+                        onClick={() => setSort(key as typeof sort)}
+                        className={`px-3 py-1 rounded-md text-xs transition-colors ${
+                          sort === key
+                            ? "bg-gray-900 text-white"
+                            : "text-gray-700 hover:bg-gray-50"
+                        }`}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
                 </div>
               </div>
             </div>
           </CardContent>
         </Card>
 
-        {/* List/Grid */}
-        <div className="mt-5 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filtered.map((bike) => (
-            <Card
-              key={bike.id}
-              role="button"
-              tabIndex={0}
-              onClick={() => handleBikeClick(bike.id)}
-              onKeyDown={(e) => e.key === "Enter" && handleBikeClick(bike.id)}
-              className="group overflow-hidden border-white/60 bg-white/90 backdrop-blur hover:shadow-lg transition-shadow cursor-pointer"
-            >
-              <CardHeader className="pb-2">
-                <div className="flex items-start justify-between gap-3">
-                  <CardTitle className="text-lg font-semibold leading-tight">
-                    {bike.name}
-                  </CardTitle>
-                  <Badge
-                    variant="outline"
-                    className={`border ${statusStyles[bike.status]}`}
-                  >
-                    {bike.status}
-                  </Badge>
-                </div>
-                <div className="text-xs text-gray-500 mt-1">
-                  {bike.year} • {bike.color} • {bike.regNo}
-                </div>
-              </CardHeader>
-
-              {/* Thumbnail / icon */}
-              <CardContent className="pt-0">
-                <div className="relative w-full h-36 rounded-lg overflow-hidden bg-gray-100">
-                  {bike.thumb ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={bike.thumb}
-                      alt={`${bike.name} photo`}
-                      className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
-                    />
-                  ) : (
-                    <div className="flex h-full w-full items-center justify-center text-gray-400">
-                      <Bike className="h-10 w-10" />
-                    </div>
-                  )}
-                </div>
-
-                <div className="mt-3 space-y-2 text-sm">
-                  <div className="flex items-center gap-2 text-gray-700">
-                    <MapPin className="h-4 w-4 text-gray-400" />
-                    <span>{bike.location}</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-gray-700">
-                    <Gauge className="h-4 w-4 text-gray-400" />
-                    <span>Odometer: <strong>{bike.odoKm.toLocaleString()} km</strong></span>
-                  </div>
-                  <div className="flex items-center gap-2 text-gray-700">
-                    <CalendarClock className="h-4 w-4 text-gray-400" />
-                    <span>
-                      Last inspection:{" "}
-                      <strong>
-                        {bike.lastInspection
-                          ? new Date(bike.lastInspection).toLocaleDateString()
-                          : "—"}
-                      </strong>
-                    </span>
-                  </div>
-                </div>
-              </CardContent>
-
-              <Separator className="mt-2" />
-
-              <CardFooter className="flex items-center justify-between">
-                <div className="text-xs text-gray-500">
-                  Tap to open details
-                </div>
-                <Button
-                  size="sm"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleBikeClick(bike.id);
-                  }}
-                  className="group/btn"
-                >
-                  View
-                  <ChevronRight className="ml-1 h-4 w-4 transition-transform group-hover/btn:translate-x-0.5" />
-                </Button>
-              </CardFooter>
-            </Card>
-          ))}
+        {/* Results Badge */}
+        <div className="flex items-center gap-2 mb-6">
+          <Badge variant="outline" className="text-xs md:text-sm">
+            Total: {filtered.length}/{bikes.length}
+          </Badge>
+          <p className="text-xs md:text-sm text-gray-600">
+            Select a vehicle to view details or start inspection
+          </p>
         </div>
 
-        {/* Empty state */}
+        {/* Vehicle Cards Grid */}
+        <VehicleCardSection filtered={filtered} />
+
+        {/* Empty State */}
         {filtered.length === 0 && (
-          <div className="mt-10 flex flex-col items-center justify-center text-center text-gray-600">
-            <Bike className="h-10 w-10 mb-2 text-gray-400" />
-            <p className="font-medium">No vehicles match your filters.</p>
-            <p className="text-sm">Try clearing the search or picking a different status.</p>
-            <Button variant="secondary" className="mt-3" onClick={() => { setQ(""); setStatus("ALL"); }}>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="mt-12 flex flex-col items-center justify-center text-center text-gray-600"
+          >
+            <Bike className="h-12 w-12 mb-4 text-gray-400" />
+            <h3 className="text-lg font-medium mb-2">No vehicles found</h3>
+            <p className="text-xs md:text-sm mb-4">
+              No vehicles match your current filters. Try adjusting your search
+              criteria.
+            </p>
+            <Button
+              variant="secondary"
+              onClick={() => {
+                setQ("");
+                setStatus("ALL");
+              }}
+              className="hover:scale-105 transition-transform"
+            >
               Reset filters
             </Button>
-          </div>
+          </motion.div>
         )}
       </div>
     </div>

--- a/app/components/data.tsx
+++ b/app/components/data.tsx
@@ -1,0 +1,183 @@
+import {
+  TrendingUp,
+  Users,
+  Clock,
+  CheckCircle,
+  Settings,
+  AlertTriangle,
+  Camera,
+  Activity,
+} from "lucide-react";
+
+export const stats = [
+  {
+    icon: Users,
+    label: "Active Inspectors",
+    value: "12",
+    trend: "+2 this week",
+    color: "text-blue-600",
+  },
+  {
+    icon: TrendingUp,
+    label: "Completion Rate",
+    value: "94%",
+    trend: "+5% vs last month",
+    color: "text-emerald-600",
+  },
+  {
+    icon: Clock,
+    label: "Avg. Time",
+    value: "2.5h",
+    trend: "-0.3h improvement",
+    color: "text-purple-600",
+  },
+  {
+    icon: CheckCircle,
+    label: "Passed Vehicles",
+    value: "847",
+    trend: "+23 today",
+    color: "text-green-600",
+  },
+];
+type VehicleStatus = "Pending" | "In Progress" | "Completed";
+
+type Vehicle = {
+  id: number;
+  name: string;
+  year: number;
+  color: string;
+  regNo: string;
+  odoKm: number;
+  location: string;
+  status: VehicleStatus;
+  lastInspection?: string;
+  thumb?: string;
+};
+
+// Dummy stats data
+export const bikes: Vehicle[] = [
+  {
+    id: 1,
+    name: "Royal Enfield Classic 350",
+    year: 2022,
+    color: "Black",
+    regNo: "MH12 AB 3456",
+    odoKm: 12850,
+    location: "Pune Yard A",
+    status: "Pending",
+    lastInspection: "2025-08-30",
+    thumb: "/images/bikes/classic350.jpg",
+  },
+  {
+    id: 2,
+    name: "Bajaj Pulsar NS200",
+    year: 2023,
+    color: "Red",
+    regNo: "DL3C XY 9087",
+    odoKm: 5400,
+    location: "Delhi Lot 3",
+    status: "In Progress",
+    lastInspection: "2025-09-02",
+    thumb: "/images/bikes/ns200.jpg",
+  },
+  {
+    id: 3,
+    name: "TVS Apache RTR 160",
+    year: 2021,
+    color: "Blue",
+    regNo: "KA05 MN 2211",
+    odoKm: 20350,
+    location: "Bengaluru Zone 1",
+    status: "Completed",
+    lastInspection: "2025-08-25",
+    thumb: "/images/bikes/apache160.jpg",
+  },
+];
+
+// Mock data for issues
+export const mockIssues = [
+  {
+    id: 1,
+    title: "Brake Pad Wear",
+    severity: "High",
+    status: "Open",
+    description:
+      "Front brake pads showing significant wear, replacement recommended",
+    category: "Safety",
+  },
+  {
+    id: 2,
+    title: "Oil Level Low",
+    severity: "Medium",
+    status: "In Progress",
+    description: "Engine oil level below recommended minimum",
+    category: "Maintenance",
+  },
+  {
+    id: 3,
+    title: "Tire Pressure",
+    severity: "Low",
+    status: "Resolved",
+    description: "Rear tire pressure was 5 PSI below recommended level",
+    category: "Routine",
+  },
+];
+
+// Mock media data
+export const mockMedia = [
+  {
+    id: 1,
+    type: "image",
+    title: "Engine Bay",
+    url: "/images/engine.jpg",
+    timestamp: "2025-09-10T10:30:00",
+  },
+  {
+    id: 2,
+    type: "video",
+    title: "Brake Test",
+    url: "/videos/brake-test.mp4",
+    duration: "2:45",
+    timestamp: "2025-09-10T11:15:00",
+  },
+  {
+    id: 3,
+    type: "image",
+    title: "Dashboard",
+    url: "/images/dashboard.jpg",
+    timestamp: "2025-09-10T10:45:00",
+  },
+  {
+    id: 4,
+    type: "video",
+    title: "Road Test",
+    url: "/videos/road-test.mp4",
+    duration: "5:20",
+    timestamp: "2025-09-10T12:00:00",
+  },
+];
+
+// Mock summary data
+export const mockSummary = {
+  overallScore: 85,
+  categories: [
+    { name: "Engine", score: 92, status: "Good" },
+    { name: "Brakes", score: 75, status: "Attention Needed" },
+    { name: "Tires", score: 88, status: "Good" },
+    { name: "Lights", score: 95, status: "Excellent" },
+    { name: "Suspension", score: 82, status: "Good" },
+    { name: "Electrical", score: 90, status: "Good" },
+  ],
+  recommendations: [
+    "Replace front brake pads within 500km",
+    "Top up engine oil at next service",
+    "Check tire alignment during next maintenance",
+  ],
+};
+
+export const tabs = [
+  { id: "details", label: "Details", icon: Settings },
+  { id: "issues", label: "Issues", icon: AlertTriangle },
+  { id: "media", label: "Media", icon: Camera },
+  { id: "summary", label: "Summary", icon: Activity },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-slot": "^1.1.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.23.12",
         "js-base64": "^3.7.7",
         "lamejs": "^1.2.1",
         "lucide-react": "^0.475.0",
@@ -3501,6 +3502,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4620,6 +4648,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-slot": "^1.1.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.23.12",
     "js-base64": "^3.7.7",
     "lamejs": "^1.2.1",
     "lucide-react": "^0.475.0",


### PR DESCRIPTION
Changes:
--
* revamp ui of PO.
* revamp details page home page and preview page.
* made it responsive for mobile and desktop preview.

SnapShot:
--
<img width="1470" height="927" alt="Screenshot 2025-09-10 at 12 43 45 AM" src="https://github.com/user-attachments/assets/94353ce1-68b9-4040-8012-a0dcb4f81569" />
<img width="1465" height="927" alt="Screenshot 2025-09-10 at 12 43 56 AM" src="https://github.com/user-attachments/assets/95b4d6de-4598-494c-b122-717850a10f45" />
<img width="1470" height="922" alt="Screenshot 2025-09-10 at 12 44 02 AM" src="https://github.com/user-attachments/assets/6d38462c-1e0a-4aef-82b8-006f33ec9d19" />
<img width="390" height="826" alt="Screenshot 2025-09-10 at 12 44 35 AM" src="https://github.com/user-attachments/assets/8b6a5d6f-d4ba-49f7-bbe4-8c48c2a9a524" />
